### PR TITLE
Fixes an "*" import in the middle of the code.

### DIFF
--- a/kicost/kicost_kicadplugin.py
+++ b/kicost/kicost_kicadplugin.py
@@ -63,7 +63,7 @@ class kicost_kicadplugin(ActionPlugin):
             bom_file = ''
         try:
             try:
-                from kicost.kicost_gui import *
+                from kicost.kicost_gui import kicost_gui
                 kicost_gui(bom_file) # If KiCad and KiCost share the same Python installation.
             except ImportError:
                 subprocess.call(('kicost', '--guide', bom_file), shell=True)


### PR DESCRIPTION
Importing everything without namespace is a bad practice.
Doing it outside module level is currently forbidden.
- Python 3.9.1 refuses to compile it.
- Flake8 reports: F406 'from kicost.kicost_gui import *' only allowed
  at module level.