### PR TITLE
Fix the name of the variable used for the fields in Altium

### DIFF
--- a/kicost/edas/eda_altium.py
+++ b/kicost/edas/eda_altium.py
@@ -149,7 +149,7 @@ def get_part_groups(in_file, ignore_fields, variant):
                 # another dot-separated variant field and store their values.
                 # Anything else is in a non-kicost namespace.
                 key_re = 'kicost(\.{})?:(?P<name>.*)'.format(variant)
-                mtch = re.match(key_re, name, flags=re.IGNORECASE)
+                mtch = re.match(key_re, hdr, flags=re.IGNORECASE)
                 if mtch:
                     # The field name is anything that came after the leading
                     # 'kicost' and variant field.


### PR DESCRIPTION
The `extract_fields_row` function was broken.
It uses an undefined variable called `name`.
I guess it should be `hdr`, the name of the field we are processing.

Note that I don't have Altium to check this is working, but the
code clearly works on `hdr`.